### PR TITLE
Add mod categories and fix submenu hover bug

### DIFF
--- a/VintageStoryModManager/Converters/Converters.cs
+++ b/VintageStoryModManager/Converters/Converters.cs
@@ -484,3 +484,28 @@ public class InstallButtonShouldShowConverter : IMultiValueConverter
         throw new NotSupportedException();
     }
 }
+
+/// <summary>
+/// Extracts the category name from a CategoryGroupKey.
+/// The CategoryGroupKey format is "{Order:D10}|{CategoryName}".
+/// </summary>
+public class CategoryNameConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (value is not string groupKey || string.IsNullOrEmpty(groupKey))
+            return string.Empty;
+
+        // The format is "{Order:D10}|{CategoryName}"
+        var pipeIndex = groupKey.IndexOf('|');
+        if (pipeIndex >= 0 && pipeIndex < groupKey.Length - 1)
+            return groupKey.Substring(pipeIndex + 1);
+
+        return groupKey;
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        throw new NotSupportedException();
+    }
+}

--- a/VintageStoryModManager/Models/ModCategory.cs
+++ b/VintageStoryModManager/Models/ModCategory.cs
@@ -1,0 +1,103 @@
+namespace VintageStoryModManager.Models;
+
+/// <summary>
+///     Represents a category for organizing mods in the mod list.
+/// </summary>
+public sealed class ModCategory
+{
+    /// <summary>
+    ///     The ID used for the default "Uncategorized" category.
+    /// </summary>
+    public const string UncategorizedId = "uncategorized";
+
+    /// <summary>
+    ///     The display name for the default "Uncategorized" category.
+    /// </summary>
+    public const string UncategorizedName = "Uncategorized";
+
+    /// <summary>
+    ///     Creates a new category with a unique ID.
+    /// </summary>
+    public ModCategory(string name, int order = 0)
+    {
+        Id = Guid.NewGuid().ToString("N");
+        Name = name ?? throw new ArgumentNullException(nameof(name));
+        Order = order;
+    }
+
+    /// <summary>
+    ///     Creates a category with a specific ID (used for deserialization or default category).
+    /// </summary>
+    public ModCategory(string id, string name, int order, bool isProfileSpecific = false)
+    {
+        Id = id ?? throw new ArgumentNullException(nameof(id));
+        Name = name ?? throw new ArgumentNullException(nameof(name));
+        Order = order;
+        IsProfileSpecific = isProfileSpecific;
+    }
+
+    /// <summary>
+    ///     Parameterless constructor for JSON deserialization.
+    /// </summary>
+    public ModCategory()
+    {
+        Id = string.Empty;
+        Name = string.Empty;
+    }
+
+    /// <summary>
+    ///     Unique identifier for this category.
+    /// </summary>
+    public string Id { get; set; }
+
+    /// <summary>
+    ///     Display name of the category.
+    /// </summary>
+    public string Name { get; set; }
+
+    /// <summary>
+    ///     Sort order for the category. Lower values appear first.
+    /// </summary>
+    public int Order { get; set; }
+
+    /// <summary>
+    ///     Whether this is the default "Uncategorized" category that cannot be deleted.
+    /// </summary>
+    public bool IsDefault => string.Equals(Id, UncategorizedId, StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    ///     Whether this category is specific to the current profile (vs global).
+    /// </summary>
+    public bool IsProfileSpecific { get; set; }
+
+    /// <summary>
+    ///     Creates the default "Uncategorized" category.
+    /// </summary>
+    public static ModCategory CreateDefault()
+    {
+        return new ModCategory(UncategorizedId, UncategorizedName, int.MaxValue);
+    }
+
+    /// <summary>
+    ///     Creates a copy of this category.
+    /// </summary>
+    public ModCategory Clone()
+    {
+        return new ModCategory(Id, Name, Order, IsProfileSpecific);
+    }
+
+    public override string ToString()
+    {
+        return $"{Name} ({Id})";
+    }
+
+    public override bool Equals(object? obj)
+    {
+        return obj is ModCategory other && string.Equals(Id, other.Id, StringComparison.OrdinalIgnoreCase);
+    }
+
+    public override int GetHashCode()
+    {
+        return StringComparer.OrdinalIgnoreCase.GetHashCode(Id);
+    }
+}

--- a/VintageStoryModManager/Resources/MainWindowStyles.xaml
+++ b/VintageStoryModManager/Resources/MainWindowStyles.xaml
@@ -10,6 +10,7 @@
     <converters:BooleanToVisibilityConverter x:Key="IMM.VisibleWhenTrueConverter" />
     <converters:BooleanToVisibilityConverter x:Key="IMM.VisibleWhenFalseConverter" IsInverted="True" />
     <converters:BooleanToVisibilityConverter x:Key="IMM.HiddenWhenFalseConverter" UseHidden="True" />
+    <converters:CategoryNameConverter x:Key="IMM.CategoryNameConverter" />
     <Thickness x:Key="IMM.RowPaddingBase">0,0,0,0</Thickness>
     <sys:Double x:Key="IMM.NormalRowHeightOffset">10</sys:Double>
     <sys:Double x:Key="IMM.CompactRowHeightOffset">-12</sys:Double>
@@ -381,31 +382,33 @@
 
                         <Popup
                             x:Name="SubMenuPopup"
-                            Margin="0,12,0,12"
                             AllowsTransparency="True"
                             Focusable="False"
-                            HorizontalOffset="2"
+                            HorizontalOffset="-10"
                             IsOpen="{Binding IsSubmenuOpen, RelativeSource={RelativeSource TemplatedParent}}"
                             Placement="Right"
                             PlacementTarget="{Binding ElementName=templateRoot}"
                             VerticalOffset="-4">
 
-                            <Border
-                                MinWidth="{Binding ActualWidth, ElementName=templateRoot}"
-                                Margin="0,0,0,4"
-                                Background="{DynamicResource Brush.Menu.Item.Background.Hover}"
-                                BorderBrush="{DynamicResource Brush.Menu.Border}"
-                                BorderThickness="1,1,1,1"
-                                CornerRadius="4"
-                                SnapsToDevicePixels="True">
-                                <ScrollViewer
-                                    CanContentScroll="False"
-                                    Focusable="False"
-                                    HorizontalScrollBarVisibility="Hidden"
-                                    VerticalScrollBarVisibility="Auto">
-                                    <ItemsPresenter Margin="4" />
-                                </ScrollViewer>
-                            </Border>
+                            <Grid>
+                                <Border Background="#01000000" />
+                                <Border
+                                    MinWidth="{Binding ActualWidth, ElementName=templateRoot}"
+                                    Margin="12,0,0,0"
+                                    Background="{DynamicResource Brush.Menu.Item.Background.Hover}"
+                                    BorderBrush="{DynamicResource Brush.Menu.Border}"
+                                    BorderThickness="1,1,1,1"
+                                    CornerRadius="4"
+                                    SnapsToDevicePixels="True">
+                                    <ScrollViewer
+                                        CanContentScroll="False"
+                                        Focusable="False"
+                                        HorizontalScrollBarVisibility="Hidden"
+                                        VerticalScrollBarVisibility="Auto">
+                                        <ItemsPresenter Margin="4" />
+                                    </ScrollViewer>
+                                </Border>
+                            </Grid>
                         </Popup>
                     </Grid>
 
@@ -429,7 +432,7 @@
                         <Trigger Property="Role" Value="TopLevelHeader">
                             <Setter TargetName="SubMenuPopup" Property="Placement" Value="Bottom" />
                             <Setter TargetName="SubMenuPopup" Property="HorizontalOffset" Value="0" />
-                            <Setter TargetName="SubMenuPopup" Property="VerticalOffset" Value="0" />
+                            <Setter TargetName="SubMenuPopup" Property="VerticalOffset" Value="-8" />
                             <Setter TargetName="ArrowGlyph" Property="Visibility" Value="Collapsed" />
                         </Trigger>
 

--- a/VintageStoryModManager/Resources/Themes/DarkVsTheme.xaml
+++ b/VintageStoryModManager/Resources/Themes/DarkVsTheme.xaml
@@ -507,17 +507,20 @@
                         HorizontalOffset="0"
                         IsOpen="{TemplateBinding IsSubmenuOpen}"
                         Placement="Bottom"
-                        VerticalOffset="20">
-                        <Border
-                            x:Name="SubMenuBorder"
-                            Background="{DynamicResource Brush.Menu.Submenu.Background}"
-                            BorderBrush="{DynamicResource Brush.Menu.Submenu.Border}"
-                            BorderThickness="1"
-                            SnapsToDevicePixels="True">
-                            <ScrollViewer CanContentScroll="True">
-                                <StackPanel IsItemsHost="True" KeyboardNavigation.DirectionalNavigation="Cycle" />
-                            </ScrollViewer>
-                        </Border>
+                        VerticalOffset="-8">
+                        <Grid Background="Transparent">
+                            <Border
+                                x:Name="SubMenuBorder"
+                                Margin="0,10,0,0"
+                                Background="{DynamicResource Brush.Menu.Submenu.Background}"
+                                BorderBrush="{DynamicResource Brush.Menu.Submenu.Border}"
+                                BorderThickness="1"
+                                SnapsToDevicePixels="True">
+                                <ScrollViewer CanContentScroll="True">
+                                    <StackPanel IsItemsHost="True" KeyboardNavigation.DirectionalNavigation="Cycle" />
+                                </ScrollViewer>
+                            </Border>
+                        </Grid>
                     </Popup>
                 </Grid>
                 <ControlTemplate.Triggers>
@@ -599,24 +602,28 @@
                         x:Name="PART_Popup"
                         AllowsTransparency="True"
                         Focusable="False"
-                        HorizontalOffset="2"
+                        HorizontalOffset="-10"
                         IsOpen="{TemplateBinding IsSubmenuOpen}"
                         Placement="Right"
                         PopupAnimation="Fade"
                         VerticalOffset="-3">
-                        <Border
-                            x:Name="SubMenuBorder"
-                            Background="{DynamicResource Brush.Menu.Submenu.Background}"
-                            BorderBrush="{DynamicResource Brush.Menu.Submenu.Border}"
-                            BorderThickness="1"
-                            SnapsToDevicePixels="True">
-                            <ScrollViewer CanContentScroll="True">
-                                <StackPanel
-                                    Margin="0"
-                                    IsItemsHost="True"
-                                    KeyboardNavigation.DirectionalNavigation="Cycle" />
-                            </ScrollViewer>
-                        </Border>
+                        <Grid>
+                            <Border Background="#01000000" />
+                            <Border
+                                x:Name="SubMenuBorder"
+                                Margin="12,0,0,0"
+                                Background="{DynamicResource Brush.Menu.Submenu.Background}"
+                                BorderBrush="{DynamicResource Brush.Menu.Submenu.Border}"
+                                BorderThickness="1"
+                                SnapsToDevicePixels="True">
+                                <ScrollViewer CanContentScroll="True">
+                                    <StackPanel
+                                        Margin="0"
+                                        IsItemsHost="True"
+                                        KeyboardNavigation.DirectionalNavigation="Cycle" />
+                                </ScrollViewer>
+                            </Border>
+                        </Grid>
                     </Popup>
                 </Grid>
                 <ControlTemplate.Triggers>

--- a/VintageStoryModManager/ViewModels/ModListItemViewModel.cs
+++ b/VintageStoryModManager/ViewModels/ModListItemViewModel.cs
@@ -78,6 +78,11 @@ public sealed class ModListItemViewModel : ObservableObject
     // Cached tag display string to avoid repeated string.Join allocations
     private string? _cachedDatabaseTagsDisplay;
 
+    // Category grouping support
+    private string _categoryId = Models.ModCategory.UncategorizedId;
+    private string _categoryName = Models.ModCategory.UncategorizedName;
+    private int _categorySortOrder = int.MaxValue;
+
     // Property change batching support
     private int _propertyChangeSuspendCount;
     private readonly HashSet<string> _pendingPropertyChanges = new();
@@ -659,6 +664,68 @@ public sealed class ModListItemViewModel : ObservableObject
         get => _isSelected;
         set => SetProperty(ref _isSelected, value);
     }
+
+    #region Category Properties
+
+    /// <summary>
+    ///     The ID of the category this mod is assigned to.
+    /// </summary>
+    public string CategoryId
+    {
+        get => _categoryId;
+        private set
+        {
+            if (SetProperty(ref _categoryId, value))
+                OnPropertyChanged(nameof(CategoryGroupKey));
+        }
+    }
+
+    /// <summary>
+    ///     The display name of the category this mod is assigned to.
+    /// </summary>
+    public string CategoryName
+    {
+        get => _categoryName;
+        private set
+        {
+            if (SetProperty(ref _categoryName, value))
+                OnPropertyChanged(nameof(CategoryGroupKey));
+        }
+    }
+
+    /// <summary>
+    ///     The sort order of the category (lower values appear first).
+    /// </summary>
+    public int CategorySortOrder
+    {
+        get => _categorySortOrder;
+        private set
+        {
+            if (SetProperty(ref _categorySortOrder, value))
+                OnPropertyChanged(nameof(CategoryGroupKey));
+        }
+    }
+
+    /// <summary>
+    ///     Composite key for grouping by category. Format: "{Order:D10}|{Name}"
+    ///     This ensures categories are sorted by order, then by name for display.
+    /// </summary>
+    public string CategoryGroupKey => $"{_categorySortOrder:D10}|{_categoryName}";
+
+    /// <summary>
+    ///     Updates the category assignment for this mod.
+    /// </summary>
+    public void UpdateCategory(string categoryId, string categoryName, int categorySortOrder)
+    {
+        using (SuspendPropertyChangeNotifications())
+        {
+            CategoryId = categoryId ?? Models.ModCategory.UncategorizedId;
+            CategoryName = categoryName ?? Models.ModCategory.UncategorizedName;
+            CategorySortOrder = categorySortOrder;
+        }
+    }
+
+    #endregion
 
     public void RefreshInternetAccessDependentState()
     {

--- a/VintageStoryModManager/Views/Dialogs/CategorySelectionDialog.xaml
+++ b/VintageStoryModManager/Views/Dialogs/CategorySelectionDialog.xaml
@@ -1,0 +1,139 @@
+<Window x:Class="VintageStoryModManager.Views.Dialogs.CategorySelectionDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:converters="clr-namespace:VintageStoryModManager.Converters"
+        Title="Set Category"
+        SizeToContent="Height"
+        Width="320"
+        MinHeight="200"
+        MaxHeight="500"
+        WindowStartupLocation="CenterOwner"
+        ResizeMode="NoResize"
+        WindowStyle="SingleBorderWindow"
+        ShowInTaskbar="False"
+        Background="{DynamicResource Brush.Window.Shell.Background.Solid}">
+    <Window.Resources>
+        <converters:BooleanToVisibilityConverter x:Key="IMM.VisibleWhenTrueConverter" />
+    </Window.Resources>
+    <Grid Margin="16"
+          Background="{DynamicResource Brush.Panel.Primary.Background.Solid}"
+          TextElement.Foreground="{DynamicResource Brush.Text.Primary}">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <!-- Header -->
+        <TextBlock Grid.Row="0"
+                   Text="Select a category:"
+                   FontSize="14"
+                   FontWeight="SemiBold"
+                   Margin="0,0,0,12"
+                   Foreground="{DynamicResource Brush.Text.Primary}" />
+
+        <!-- Category List -->
+        <ListBox x:Name="CategoryListBox"
+                 Grid.Row="1"
+                 MinHeight="100"
+                 MaxHeight="300"
+                 Background="{DynamicResource Brush.Panel.Secondary.Background.Solid}"
+                 BorderBrush="{DynamicResource Brush.Button.Bevel.Light}"
+                 BorderThickness="1"
+                 SelectionMode="Single"
+                 MouseDoubleClick="CategoryListBox_OnMouseDoubleClick">
+            <ListBox.ItemContainerStyle>
+                <Style TargetType="{x:Type ListBoxItem}">
+                    <Setter Property="Padding" Value="12,10" />
+                    <Setter Property="FontSize" Value="13" />
+                    <Setter Property="Foreground" Value="{DynamicResource Brush.Text.Primary}" />
+                    <Setter Property="Background" Value="Transparent" />
+                    <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                    <Setter Property="Template">
+                        <Setter.Value>
+                            <ControlTemplate TargetType="{x:Type ListBoxItem}">
+                                <Border x:Name="Bd"
+                                        Background="{TemplateBinding Background}"
+                                        BorderBrush="{TemplateBinding BorderBrush}"
+                                        BorderThickness="{TemplateBinding BorderThickness}"
+                                        Padding="{TemplateBinding Padding}">
+                                    <ContentPresenter HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                                      VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
+                                </Border>
+                                <ControlTemplate.Triggers>
+                                    <Trigger Property="IsSelected" Value="True">
+                                        <Setter TargetName="Bd" Property="Background" Value="{DynamicResource Brush.Accent.Primary}" />
+                                        <Setter Property="Foreground" Value="White" />
+                                    </Trigger>
+                                    <MultiTrigger>
+                                        <MultiTrigger.Conditions>
+                                            <Condition Property="IsMouseOver" Value="True" />
+                                            <Condition Property="IsSelected" Value="False" />
+                                        </MultiTrigger.Conditions>
+                                        <Setter TargetName="Bd" Property="Background" Value="{DynamicResource Brush.Panel.Primary.Background.Solid}" />
+                                    </MultiTrigger>
+                                </ControlTemplate.Triggers>
+                            </ControlTemplate>
+                        </Setter.Value>
+                    </Setter>
+                </Style>
+            </ListBox.ItemContainerStyle>
+            <ListBox.ItemTemplate>
+                <DataTemplate>
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock Text="{Binding DisplayName}">
+                            <TextBlock.Style>
+                                <Style TargetType="TextBlock">
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding IsProfileSpecific}" Value="True">
+                                            <Setter Property="Foreground" Value="#4EC9B0" />
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </TextBlock.Style>
+                        </TextBlock>
+                        <TextBlock Text=" (profile)"
+                                   FontStyle="Italic"
+                                   Opacity="0.7"
+                                   Foreground="#4EC9B0"
+                                   Visibility="{Binding IsProfileSpecific, Converter={StaticResource IMM.VisibleWhenTrueConverter}}" />
+                    </StackPanel>
+                </DataTemplate>
+            </ListBox.ItemTemplate>
+        </ListBox>
+
+        <!-- Buttons -->
+        <Grid Grid.Row="2" Margin="0,16,0,0">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+
+            <Button x:Name="NewCategoryButton"
+                    Grid.Column="0"
+                    Content="New Category..."
+                    HorizontalAlignment="Left"
+                    MinWidth="110"
+                    Padding="12,8"
+                    Click="NewCategoryButton_OnClick" />
+
+            <Button x:Name="OkButton"
+                    Grid.Column="1"
+                    Content="OK"
+                    IsDefault="True"
+                    MinWidth="80"
+                    Padding="12,8"
+                    Margin="0,0,8,0"
+                    Click="OkButton_OnClick" />
+
+            <Button x:Name="CancelButton"
+                    Grid.Column="2"
+                    Content="Cancel"
+                    IsCancel="True"
+                    MinWidth="80"
+                    Padding="12,8"
+                    Click="CancelButton_OnClick" />
+        </Grid>
+    </Grid>
+</Window>

--- a/VintageStoryModManager/Views/Dialogs/CategorySelectionDialog.xaml.cs
+++ b/VintageStoryModManager/Views/Dialogs/CategorySelectionDialog.xaml.cs
@@ -1,0 +1,90 @@
+using System.Windows;
+using System.Windows.Input;
+using VintageStoryModManager.Models;
+
+namespace VintageStoryModManager.Views.Dialogs;
+
+public partial class CategorySelectionDialog : Window
+{
+    private readonly Action<string> _onCreateCategory;
+
+    public CategorySelectionDialog(
+        IReadOnlyList<ModCategory> categories,
+        string currentCategoryId,
+        Action<string> onCreateCategory)
+    {
+        InitializeComponent();
+
+        _onCreateCategory = onCreateCategory;
+
+        // Create view models for the categories
+        var items = categories.Select(c => new CategoryItemViewModel
+        {
+            Id = c.Id,
+            Name = c.Name,
+            IsCurrentCategory = string.Equals(c.Id, currentCategoryId, StringComparison.OrdinalIgnoreCase),
+            IsProfileSpecific = c.IsProfileSpecific
+        }).ToList();
+
+        CategoryListBox.ItemsSource = items;
+
+        // Select the current category
+        var currentItem = items.FirstOrDefault(i => i.IsCurrentCategory);
+        if (currentItem != null)
+        {
+            CategoryListBox.SelectedItem = currentItem;
+        }
+    }
+
+    public string? SelectedCategoryId { get; private set; }
+
+    private void OkButton_OnClick(object sender, RoutedEventArgs e)
+    {
+        if (CategoryListBox.SelectedItem is CategoryItemViewModel selected)
+        {
+            SelectedCategoryId = selected.Id;
+            DialogResult = true;
+        }
+    }
+
+    private void CancelButton_OnClick(object sender, RoutedEventArgs e)
+    {
+        DialogResult = false;
+    }
+
+    private void CategoryListBox_OnMouseDoubleClick(object sender, MouseButtonEventArgs e)
+    {
+        if (CategoryListBox.SelectedItem is CategoryItemViewModel selected)
+        {
+            SelectedCategoryId = selected.Id;
+            DialogResult = true;
+        }
+    }
+
+    private void NewCategoryButton_OnClick(object sender, RoutedEventArgs e)
+    {
+        var inputDialog = new TextInputDialog("New Category", "Enter category name:")
+        {
+            Owner = this,
+            WindowStartupLocation = WindowStartupLocation.CenterOwner
+        };
+
+        if (inputDialog.ShowDialog() == true && !string.IsNullOrWhiteSpace(inputDialog.InputText))
+        {
+            _onCreateCategory(inputDialog.InputText.Trim());
+
+            // Close this dialog so it can be reopened with the new category
+            DialogResult = false;
+        }
+    }
+
+    private class CategoryItemViewModel
+    {
+        public string Id { get; set; } = string.Empty;
+        public string Name { get; set; } = string.Empty;
+        public bool IsCurrentCategory { get; set; }
+        public bool IsProfileSpecific { get; set; }
+
+        public string DisplayName => IsCurrentCategory ? $"✓  {Name}" : $"    {Name}";
+    }
+}

--- a/VintageStoryModManager/Views/Dialogs/ManageCategoriesDialog.xaml
+++ b/VintageStoryModManager/Views/Dialogs/ManageCategoriesDialog.xaml
@@ -1,0 +1,217 @@
+<Window x:Class="VintageStoryModManager.Views.Dialogs.ManageCategoriesDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Manage Categories"
+        Width="500"
+        Height="450"
+        MinWidth="400"
+        MinHeight="350"
+        WindowStartupLocation="CenterOwner"
+        ResizeMode="CanResize"
+        WindowStyle="SingleBorderWindow"
+        ShowInTaskbar="False"
+        Background="{DynamicResource Brush.Window.Shell.Background.Solid}">
+    <Grid Margin="16"
+          Background="{DynamicResource Brush.Panel.Primary.Background.Solid}"
+          TextElement.Foreground="{DynamicResource Brush.Text.Primary}">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <!-- Global Categories Section -->
+        <TextBlock Grid.Row="0"
+                   Text="Global Categories (shared across all profiles)"
+                   FontSize="14"
+                   FontWeight="SemiBold"
+                   Margin="0,0,0,8"
+                   Foreground="{DynamicResource Brush.Text.Primary}" />
+
+        <Grid Grid.Row="1">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+
+            <ListBox x:Name="GlobalCategoriesListBox"
+                     Grid.Column="0"
+                     Background="{DynamicResource Brush.Panel.Secondary.Background.Solid}"
+                     BorderBrush="{DynamicResource Brush.Button.Bevel.Light}"
+                     BorderThickness="1"
+                     SelectionMode="Single">
+                <ListBox.ItemContainerStyle>
+                    <Style TargetType="{x:Type ListBoxItem}">
+                        <Setter Property="Padding" Value="12,8" />
+                        <Setter Property="FontSize" Value="13" />
+                        <Setter Property="Foreground" Value="{DynamicResource Brush.Text.Primary}" />
+                        <Setter Property="Background" Value="Transparent" />
+                        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                        <Setter Property="Template">
+                            <Setter.Value>
+                                <ControlTemplate TargetType="{x:Type ListBoxItem}">
+                                    <Border x:Name="Bd"
+                                            Background="{TemplateBinding Background}"
+                                            BorderBrush="{TemplateBinding BorderBrush}"
+                                            BorderThickness="{TemplateBinding BorderThickness}"
+                                            Padding="{TemplateBinding Padding}">
+                                        <ContentPresenter HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                                          VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
+                                    </Border>
+                                    <ControlTemplate.Triggers>
+                                        <Trigger Property="IsSelected" Value="True">
+                                            <Setter TargetName="Bd" Property="Background" Value="{DynamicResource Brush.Accent.Primary}" />
+                                            <Setter Property="Foreground" Value="White" />
+                                        </Trigger>
+                                        <MultiTrigger>
+                                            <MultiTrigger.Conditions>
+                                                <Condition Property="IsMouseOver" Value="True" />
+                                                <Condition Property="IsSelected" Value="False" />
+                                            </MultiTrigger.Conditions>
+                                            <Setter TargetName="Bd" Property="Background" Value="{DynamicResource Brush.Panel.Primary.Background.Solid}" />
+                                        </MultiTrigger>
+                                    </ControlTemplate.Triggers>
+                                </ControlTemplate>
+                            </Setter.Value>
+                        </Setter>
+                    </Style>
+                </ListBox.ItemContainerStyle>
+                <ListBox.ItemTemplate>
+                    <DataTemplate>
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Grid.Column="0" Text="{Binding Name}" VerticalAlignment="Center" />
+                            <TextBlock Grid.Column="1"
+                                       Text="(default)"
+                                       FontStyle="Italic"
+                                       Opacity="0.6"
+                                       Margin="8,0,0,0"
+                                       VerticalAlignment="Center"
+                                       Visibility="{Binding IsDefault, Converter={StaticResource IMM.VisibleWhenTrueConverter}}" />
+                        </Grid>
+                    </DataTemplate>
+                </ListBox.ItemTemplate>
+            </ListBox>
+
+            <StackPanel Grid.Column="1" Margin="8,0,0,0" VerticalAlignment="Top">
+                <Button x:Name="AddGlobalButton"
+                        Content="Add"
+                        MinWidth="70"
+                        Padding="8,6"
+                        Margin="0,0,0,4"
+                        Click="AddGlobalButton_OnClick" />
+                <Button x:Name="RenameGlobalButton"
+                        Content="Rename"
+                        MinWidth="70"
+                        Padding="8,6"
+                        Margin="0,0,0,4"
+                        Click="RenameGlobalButton_OnClick" />
+                <Button x:Name="DeleteGlobalButton"
+                        Content="Delete"
+                        MinWidth="70"
+                        Padding="8,6"
+                        Click="DeleteGlobalButton_OnClick" />
+            </StackPanel>
+        </Grid>
+
+        <!-- Profile Categories Section -->
+        <TextBlock Grid.Row="2"
+                   Text="Profile Categories (only for current profile)"
+                   FontSize="14"
+                   FontWeight="SemiBold"
+                   Margin="0,16,0,8"
+                   Foreground="{DynamicResource Brush.Text.Primary}" />
+
+        <Grid Grid.Row="3">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+
+            <ListBox x:Name="ProfileCategoriesListBox"
+                     Grid.Column="0"
+                     Background="{DynamicResource Brush.Panel.Secondary.Background.Solid}"
+                     BorderBrush="{DynamicResource Brush.Button.Bevel.Light}"
+                     BorderThickness="1"
+                     SelectionMode="Single">
+                <ListBox.ItemContainerStyle>
+                    <Style TargetType="{x:Type ListBoxItem}">
+                        <Setter Property="Padding" Value="12,8" />
+                        <Setter Property="FontSize" Value="13" />
+                        <Setter Property="Foreground" Value="{DynamicResource Brush.Text.Primary}" />
+                        <Setter Property="Background" Value="Transparent" />
+                        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                        <Setter Property="Template">
+                            <Setter.Value>
+                                <ControlTemplate TargetType="{x:Type ListBoxItem}">
+                                    <Border x:Name="Bd"
+                                            Background="{TemplateBinding Background}"
+                                            BorderBrush="{TemplateBinding BorderBrush}"
+                                            BorderThickness="{TemplateBinding BorderThickness}"
+                                            Padding="{TemplateBinding Padding}">
+                                        <ContentPresenter HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                                          VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
+                                    </Border>
+                                    <ControlTemplate.Triggers>
+                                        <Trigger Property="IsSelected" Value="True">
+                                            <Setter TargetName="Bd" Property="Background" Value="{DynamicResource Brush.Accent.Primary}" />
+                                            <Setter Property="Foreground" Value="White" />
+                                        </Trigger>
+                                        <MultiTrigger>
+                                            <MultiTrigger.Conditions>
+                                                <Condition Property="IsMouseOver" Value="True" />
+                                                <Condition Property="IsSelected" Value="False" />
+                                            </MultiTrigger.Conditions>
+                                            <Setter TargetName="Bd" Property="Background" Value="{DynamicResource Brush.Panel.Primary.Background.Solid}" />
+                                        </MultiTrigger>
+                                    </ControlTemplate.Triggers>
+                                </ControlTemplate>
+                            </Setter.Value>
+                        </Setter>
+                    </Style>
+                </ListBox.ItemContainerStyle>
+                <ListBox.ItemTemplate>
+                    <DataTemplate>
+                        <TextBlock Text="{Binding Name}" />
+                    </DataTemplate>
+                </ListBox.ItemTemplate>
+            </ListBox>
+
+            <StackPanel Grid.Column="1" Margin="8,0,0,0" VerticalAlignment="Top">
+                <Button x:Name="AddProfileButton"
+                        Content="Add"
+                        MinWidth="70"
+                        Padding="8,6"
+                        Margin="0,0,0,4"
+                        Click="AddProfileButton_OnClick" />
+                <Button x:Name="RenameProfileButton"
+                        Content="Rename"
+                        MinWidth="70"
+                        Padding="8,6"
+                        Margin="0,0,0,4"
+                        Click="RenameProfileButton_OnClick" />
+                <Button x:Name="DeleteProfileButton"
+                        Content="Delete"
+                        MinWidth="70"
+                        Padding="8,6"
+                        Click="DeleteProfileButton_OnClick" />
+            </StackPanel>
+        </Grid>
+
+        <!-- Close Button -->
+        <Button x:Name="CloseButton"
+                Grid.Row="4"
+                Content="Close"
+                HorizontalAlignment="Right"
+                MinWidth="80"
+                Padding="12,8"
+                Margin="0,16,0,0"
+                IsCancel="True"
+                Click="CloseButton_OnClick" />
+    </Grid>
+</Window>

--- a/VintageStoryModManager/Views/Dialogs/ManageCategoriesDialog.xaml.cs
+++ b/VintageStoryModManager/Views/Dialogs/ManageCategoriesDialog.xaml.cs
@@ -1,0 +1,158 @@
+using System.Windows;
+using VintageStoryModManager.Models;
+using VintageStoryModManager.ViewModels;
+using MessageBox = System.Windows.MessageBox;
+
+namespace VintageStoryModManager.Views.Dialogs;
+
+public partial class ManageCategoriesDialog : Window
+{
+    private readonly MainViewModel _viewModel;
+
+    public ManageCategoriesDialog(MainViewModel viewModel)
+    {
+        InitializeComponent();
+        _viewModel = viewModel;
+        RefreshLists();
+    }
+
+    private void RefreshLists()
+    {
+        GlobalCategoriesListBox.ItemsSource = _viewModel.GetGlobalCategories();
+        ProfileCategoriesListBox.ItemsSource = _viewModel.GetProfileCategories();
+    }
+
+    private void AddGlobalButton_OnClick(object sender, RoutedEventArgs e)
+    {
+        var dialog = new TextInputDialog("New Global Category", "Enter category name:")
+        {
+            Owner = this,
+            WindowStartupLocation = WindowStartupLocation.CenterOwner
+        };
+
+        if (dialog.ShowDialog() == true && !string.IsNullOrWhiteSpace(dialog.InputText))
+        {
+            _viewModel.CreateCategory(dialog.InputText.Trim());
+            RefreshLists();
+        }
+    }
+
+    private void RenameGlobalButton_OnClick(object sender, RoutedEventArgs e)
+    {
+        if (GlobalCategoriesListBox.SelectedItem is not ModCategory category)
+        {
+            MessageBox.Show(this, "Please select a category to rename.", "No Selection", MessageBoxButton.OK, MessageBoxImage.Information);
+            return;
+        }
+
+        if (category.IsDefault)
+        {
+            MessageBox.Show(this, "The default 'Uncategorized' category cannot be renamed.", "Cannot Rename", MessageBoxButton.OK, MessageBoxImage.Warning);
+            return;
+        }
+
+        var dialog = new TextInputDialog("Rename Category", "Enter new name:", category.Name)
+        {
+            Owner = this,
+            WindowStartupLocation = WindowStartupLocation.CenterOwner
+        };
+
+        if (dialog.ShowDialog() == true && !string.IsNullOrWhiteSpace(dialog.InputText))
+        {
+            _viewModel.RenameCategory(category.Id, dialog.InputText.Trim());
+            RefreshLists();
+        }
+    }
+
+    private void DeleteGlobalButton_OnClick(object sender, RoutedEventArgs e)
+    {
+        if (GlobalCategoriesListBox.SelectedItem is not ModCategory category)
+        {
+            MessageBox.Show(this, "Please select a category to delete.", "No Selection", MessageBoxButton.OK, MessageBoxImage.Information);
+            return;
+        }
+
+        if (category.IsDefault)
+        {
+            MessageBox.Show(this, "The default 'Uncategorized' category cannot be deleted.", "Cannot Delete", MessageBoxButton.OK, MessageBoxImage.Warning);
+            return;
+        }
+
+        var result = MessageBox.Show(
+            this,
+            $"Are you sure you want to delete the category '{category.Name}'?\n\nAll mods in this category will be moved to 'Uncategorized'.",
+            "Confirm Delete",
+            MessageBoxButton.YesNo,
+            MessageBoxImage.Question);
+
+        if (result == MessageBoxResult.Yes)
+        {
+            _viewModel.DeleteCategory(category.Id);
+            RefreshLists();
+        }
+    }
+
+    private void AddProfileButton_OnClick(object sender, RoutedEventArgs e)
+    {
+        var dialog = new TextInputDialog("New Profile Category", "Enter category name:")
+        {
+            Owner = this,
+            WindowStartupLocation = WindowStartupLocation.CenterOwner
+        };
+
+        if (dialog.ShowDialog() == true && !string.IsNullOrWhiteSpace(dialog.InputText))
+        {
+            _viewModel.CreateProfileCategory(dialog.InputText.Trim());
+            RefreshLists();
+        }
+    }
+
+    private void RenameProfileButton_OnClick(object sender, RoutedEventArgs e)
+    {
+        if (ProfileCategoriesListBox.SelectedItem is not ModCategory category)
+        {
+            MessageBox.Show(this, "Please select a category to rename.", "No Selection", MessageBoxButton.OK, MessageBoxImage.Information);
+            return;
+        }
+
+        var dialog = new TextInputDialog("Rename Category", "Enter new name:", category.Name)
+        {
+            Owner = this,
+            WindowStartupLocation = WindowStartupLocation.CenterOwner
+        };
+
+        if (dialog.ShowDialog() == true && !string.IsNullOrWhiteSpace(dialog.InputText))
+        {
+            _viewModel.RenameCategory(category.Id, dialog.InputText.Trim());
+            RefreshLists();
+        }
+    }
+
+    private void DeleteProfileButton_OnClick(object sender, RoutedEventArgs e)
+    {
+        if (ProfileCategoriesListBox.SelectedItem is not ModCategory category)
+        {
+            MessageBox.Show(this, "Please select a category to delete.", "No Selection", MessageBoxButton.OK, MessageBoxImage.Information);
+            return;
+        }
+
+        var result = MessageBox.Show(
+            this,
+            $"Are you sure you want to delete the category '{category.Name}'?\n\nAll mods in this category will be moved to 'Uncategorized'.",
+            "Confirm Delete",
+            MessageBoxButton.YesNo,
+            MessageBoxImage.Question);
+
+        if (result == MessageBoxResult.Yes)
+        {
+            _viewModel.DeleteCategory(category.Id);
+            RefreshLists();
+        }
+    }
+
+    private void CloseButton_OnClick(object sender, RoutedEventArgs e)
+    {
+        DialogResult = true;
+        Close();
+    }
+}

--- a/VintageStoryModManager/Views/Dialogs/TextInputDialog.xaml
+++ b/VintageStoryModManager/Views/Dialogs/TextInputDialog.xaml
@@ -1,0 +1,58 @@
+<Window x:Class="VintageStoryModManager.Views.Dialogs.TextInputDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Input"
+        SizeToContent="WidthAndHeight"
+        MinWidth="300"
+        WindowStartupLocation="CenterOwner"
+        ResizeMode="NoResize"
+        WindowStyle="SingleBorderWindow"
+        ShowInTaskbar="False"
+        Background="{DynamicResource Brush.Window.Shell.Background.Solid}"
+        FocusManager.FocusedElement="{Binding ElementName=InputTextBox}">
+    <Grid Margin="16"
+          Background="{DynamicResource Brush.Panel.Primary.Background.Solid}"
+          TextElement.Foreground="{DynamicResource Brush.Text.Primary}">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <!-- Prompt -->
+        <TextBlock x:Name="PromptTextBlock"
+                   Grid.Row="0"
+                   FontSize="13"
+                   Margin="0,0,0,8"
+                   Foreground="{DynamicResource Brush.Text.Primary}" />
+
+        <!-- Input -->
+        <TextBox x:Name="InputTextBox"
+                 Grid.Row="1"
+                 MinWidth="260"
+                 Padding="8,6"
+                 FontSize="13"
+                 Background="{DynamicResource Brush.Dialog.TextBox.Background}"
+                 Foreground="{DynamicResource Brush.Text.Primary}"
+                 BorderBrush="{DynamicResource Brush.Button.Bevel.Light}"
+                 BorderThickness="1" />
+
+        <!-- Buttons -->
+        <StackPanel Grid.Row="2"
+                    Orientation="Horizontal"
+                    HorizontalAlignment="Right"
+                    Margin="0,16,0,0">
+            <Button Content="OK"
+                    IsDefault="True"
+                    MinWidth="80"
+                    Padding="12,8"
+                    Margin="0,0,8,0"
+                    Click="OkButton_OnClick" />
+            <Button Content="Cancel"
+                    IsCancel="True"
+                    MinWidth="80"
+                    Padding="12,8"
+                    Click="CancelButton_OnClick" />
+        </StackPanel>
+    </Grid>
+</Window>

--- a/VintageStoryModManager/Views/Dialogs/TextInputDialog.xaml.cs
+++ b/VintageStoryModManager/Views/Dialogs/TextInputDialog.xaml.cs
@@ -1,0 +1,31 @@
+using System.Windows;
+
+namespace VintageStoryModManager.Views.Dialogs;
+
+public partial class TextInputDialog : Window
+{
+    public TextInputDialog(string title, string prompt, string defaultValue = "")
+    {
+        InitializeComponent();
+
+        Title = title;
+        PromptTextBlock.Text = prompt;
+        InputTextBox.Text = defaultValue;
+        InputTextBox.SelectAll();
+    }
+
+    public string InputText => InputTextBox.Text;
+
+    private void OkButton_OnClick(object sender, RoutedEventArgs e)
+    {
+        if (!string.IsNullOrWhiteSpace(InputTextBox.Text))
+        {
+            DialogResult = true;
+        }
+    }
+
+    private void CancelButton_OnClick(object sender, RoutedEventArgs e)
+    {
+        DialogResult = false;
+    }
+}

--- a/VintageStoryModManager/Views/MainWindow.xaml
+++ b/VintageStoryModManager/Views/MainWindow.xaml
@@ -308,6 +308,19 @@
                             IsCheckable="True"
                             IsChecked="{Binding IsCompactView, Mode=TwoWay}"
                             Style="{StaticResource ToggleMenuItemStyle}" />
+                        <MenuItem
+                            Height="35"
+                            Header="_Group by Category"
+                            IsCheckable="True"
+                            IsChecked="{Binding IsGroupedByCategory, Mode=TwoWay}"
+                            Style="{StaticResource ToggleMenuItemStyle}"
+                            Visibility="{Binding IsViewingMainTab, Converter={StaticResource IMM.BooleanToVisibilityConverter}}" />
+                        <MenuItem
+                            Height="35"
+                            Header="_Manage Categories..."
+                            Click="ManageCategoriesMenuItem_OnClick"
+                            Visibility="{Binding IsViewingMainTab, Converter={StaticResource IMM.BooleanToVisibilityConverter}}" />
+                        <Separator Visibility="{Binding IsViewingMainTab, Converter={StaticResource IMM.BooleanToVisibilityConverter}}" />
                         <MenuItem x:Name="ThemesMenuItem" Height="35" Header="_Themes">
                             <MenuItem
                                 x:Name="VintageStoryThemeMenuItem"
@@ -758,6 +771,39 @@
                                     <DataGrid.DragIndicatorStyle>
                                         <Style />
                                     </DataGrid.DragIndicatorStyle>
+                                    <DataGrid.GroupStyle>
+                                        <GroupStyle>
+                                            <GroupStyle.Panel>
+                                                <ItemsPanelTemplate>
+                                                    <DataGridRowsPresenter />
+                                                </ItemsPanelTemplate>
+                                            </GroupStyle.Panel>
+                                            <GroupStyle.HeaderTemplate>
+                                                <DataTemplate>
+                                                    <Border
+                                                        Margin="0,8,0,4"
+                                                        Padding="12,8"
+                                                        Background="{DynamicResource Brush.Panel.Secondary.Background.Solid}"
+                                                        BorderBrush="{DynamicResource Brush.Button.Bevel.Light}"
+                                                        BorderThickness="1"
+                                                        CornerRadius="8">
+                                                        <StackPanel Orientation="Horizontal">
+                                                            <TextBlock
+                                                                FontSize="14"
+                                                                FontWeight="SemiBold"
+                                                                Foreground="{DynamicResource Brush.Text.Primary}"
+                                                                Text="{Binding Name, Converter={StaticResource IMM.CategoryNameConverter}}" />
+                                                            <TextBlock
+                                                                Margin="8,0,0,0"
+                                                                FontSize="12"
+                                                                Foreground="{DynamicResource Brush.Text.Subtle}"
+                                                                Text="{Binding ItemCount, StringFormat='({0} mods)'}" />
+                                                        </StackPanel>
+                                                    </Border>
+                                                </DataTemplate>
+                                            </GroupStyle.HeaderTemplate>
+                                        </GroupStyle>
+                                    </DataGrid.GroupStyle>
                                     <DataGrid.CellStyle>
                                         <StaticResource ResourceKey="IMM.DataGridCellBaseStyle" />
                                     </DataGrid.CellStyle>
@@ -768,6 +814,7 @@
                                             <EventSetter Event="FrameworkElement.Unloaded" Handler="ModsDataGridRow_OnUnloaded" />
                                             <EventSetter Event="UIElement.MouseEnter" Handler="ModsDataGridRow_OnMouseEnter" />
                                             <EventSetter Event="UIElement.MouseLeave" Handler="ModsDataGridRow_OnMouseLeave" />
+                                            <EventSetter Event="UIElement.MouseRightButtonUp" Handler="ModsDataGridRow_OnMouseRightButtonUp" />
                                         </Style>
                                     </DataGrid.RowStyle>
                                     <DataGrid.Columns>


### PR DESCRIPTION
## Summary

- **Mod Categories**: Added a category system for organizing mods
  - Right-click context menu to assign mods to categories or create new ones
  - "Manage Categories" dialog accessible from the View menu
  - Support for global categories (shared across profiles) and profile-specific overrides
  - Visual grouping in the mod list by category (toggle via View > Group by Category)
  - Drag-and-drop support to move mods between categories

- **Submenu Bug Fix**: Fixed an issue where submenus would disappear when moving the cursor from the parent menu item to the submenu, making it impossible to select options like themes, profiles, or presets. Added transparent hit-test area to bridge the gap between menu and submenu.

## Test Plan

- [ ] Right-click a mod and verify category selection dialog appears
- [ ] Create a new category and assign a mod to it
- [ ] Enable "Group by Category" from View menu and verify mods are grouped
- [ ] Open "Manage Categories" dialog and verify categories can be added/edited/deleted
- [ ] Create a profile-specific category and verify it only appears in that profile
- [ ] Switch profiles and verify category assignments are per-profile
- [ ] Hover over menu items with submenus (Theme, Profiles, Presets) and verify submenus remain open when moving cursor to them
- [ ] Verify theme/profile/preset selection works correctly